### PR TITLE
Pull Request: Menampilkan Penerima dan Kehadiran pada Detail Undangan

### DIFF
--- a/app/Http/Controllers/Orion/RsiaUndanganController.php
+++ b/app/Http/Controllers/Orion/RsiaUndanganController.php
@@ -37,7 +37,7 @@ class RsiaUndanganController extends Controller
     {
         $query = parent::buildIndexFetchQuery($request, $requestedRelations);
         $query->select(['no_surat', 'model'])->groupBy('no_surat', 'model');
-        
+
         return $query;
     }
 

--- a/app/Http/Controllers/v2/RsiaUndanganController.php
+++ b/app/Http/Controllers/v2/RsiaUndanganController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Controllers\v2;
+
+use App\Http\Controllers\Controller;
+use App\Models\RsiaNotulen;
+use App\Models\RsiaPenerimaUndangan;
+use Illuminate\Http\Request;
+
+class RsiaUndanganController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  string $base64_no_surat
+     * @return \Illuminate\Http\Response
+     */
+    public function show($base64_no_surat)
+    {
+        try {
+            $no_surat = base64_decode($base64_no_surat);
+            $undangan = RsiaPenerimaUndangan::where('no_surat', $no_surat)->first();
+
+            if (!$undangan) {
+                return response()->json(['message' => 'Data tidak ditemukan'], 404);
+            }
+
+            $model = new $undangan->model;
+            $undangan = $model->with('penerima.kehadiran')->find($no_surat);
+            
+            return new \App\Http\Resources\RealDataResource($undangan);
+
+        } catch (\Exception $e) {
+            return response()->json(['message' => $e->getMessage()], 500);
+        }
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+
+    /**
+     * Get notulen from surat
+     *
+     * @param  string $base64_no_surat
+     * @return \Illuminate\Http\Response
+     */
+    public function notulen($base64_no_surat)
+    {
+        try {
+            $no_surat = base64_decode($base64_no_surat);
+            $notulen = RsiaNotulen::where('no_surat', $no_surat)->with('notulis')->first();
+            
+            return new \App\Http\Resources\RealDataResource($notulen);
+        } catch (\Exception $e) {
+            return response()->json(['message' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/app/Models/RsiaKehadiranRapat.php
+++ b/app/Models/RsiaKehadiranRapat.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Awobaz\Compoships\Compoships;
 use Illuminate\Database\Eloquent\Model;
+use Thiagoprz\CompositeKey\HasCompositeKey;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 /**
  * App\Models\RsiaKehadiranRapat
@@ -26,7 +28,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class RsiaKehadiranRapat extends Model
 {
-    use HasFactory;
+    use HasCompositeKey, Compoships;
 
     protected $table = 'rsia_kehadiran_rapat';
 

--- a/app/Models/RsiaNotulen.php
+++ b/app/Models/RsiaNotulen.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class RsiaNotulen extends Model
+{
+    use HasFactory;
+
+    /**
+     * The table associated with the model
+     *
+     * @var string
+     */
+    protected $table = 'rsia_notulen';
+
+    /**
+     * The primary key associated with the table
+     *
+     * @var string
+     */
+    protected $primaryKey = "no_surat";
+
+    /**
+     * The primary key associated with the table
+     *
+     * @var string
+     */
+    public $incrementing = false;
+
+    /**
+     * The primary key associated with the table
+     *
+     * @var string
+     */
+    public $timestamps = false;
+
+    /**
+     * The attributes that are mass assignable
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that are casted
+     *
+     * @var array
+     */
+    protected $casts = [
+        'no_surat' => 'string',
+        'notulis' => 'string',
+        'tipe' => 'string',
+        'model' => 'string',
+    ];
+
+
+    /**
+     * Get the notulis that owns the RsiaNotulen
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function notulis()
+    {
+        return $this->belongsTo(Pegawai::class, 'notulis_nik', 'nik')->select('nik', 'nama', 'jbtn', 'bidang');
+    }
+}

--- a/app/Models/RsiaPenerimaUndangan.php
+++ b/app/Models/RsiaPenerimaUndangan.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Awobaz\Compoships\Compoships;
 use Illuminate\Database\Eloquent\Model;
 use Thiagoprz\CompositeKey\HasCompositeKey;
 
@@ -26,7 +27,7 @@ use Thiagoprz\CompositeKey\HasCompositeKey;
  */
 class RsiaPenerimaUndangan extends Model
 {
-    use HasCompositeKey;
+    use HasCompositeKey, Compoships;
 
     protected $table = 'rsia_penerima_undangan';
 
@@ -41,12 +42,16 @@ class RsiaPenerimaUndangan extends Model
     protected $casts = [
         'no_surat' => 'string',
         'penerima' => 'string',
-        'tipe' => 'string',
-        'model' => 'string',
+        'tipe'     => 'string',
+        'model'    => 'string',
     ];
 
 
-    // detail penerima
+    public function pegawai()
+    {
+        return $this->belongsTo(Pegawai::class, 'penerima', 'nik')->select('nik', 'nama', 'jbtn', 'departemen', 'bidang');
+    }
+    
     public function detail()
     {
         return $this->belongsTo(Pegawai::class, 'penerima', 'nik')->select('nik', 'nama', 'jbtn', 'departemen', 'bidang');
@@ -79,5 +84,10 @@ class RsiaPenerimaUndangan extends Model
     public function scopeWithDetail($query)
     {
         return $query->with(['relatedModel', 'detail']);
+    }
+
+    public function kehadiran()
+    {
+        return $this->hasOne(RsiaKehadiranRapat::class, ['no_surat', 'nik'], ['no_surat', 'penerima'])->without('pegawai');
     }
 }

--- a/app/Models/RsiaSuratInternal.php
+++ b/app/Models/RsiaSuratInternal.php
@@ -57,6 +57,12 @@ class RsiaSuratInternal extends Model
     public $timestamps = false;
 
 
+    public function penerima()
+    {
+        return $this->hasMany(RsiaPenerimaUndangan::class, 'no_surat', 'no_surat')
+            ->select('no_surat', 'penerima', 'updated_at')->with('pegawai');
+    }
+
     public function penerimaUndangan()
     {
         return $this->hasMany(RsiaPenerimaUndangan::class, 'no_surat', 'no_surat');

--- a/routes/partials/undangan.php
+++ b/routes/partials/undangan.php
@@ -6,7 +6,8 @@ use Illuminate\Support\Facades\Route;
 // FIXME : review ulang endpoint undangan (SEMUA) 
 Route::middleware(['user-aes', 'claim:role,pegawai'])->prefix('undangan')->group(function () {
     // ==================== PENERIMA UNDANGAN 
-    Orion::resource('penerima', \App\Http\Controllers\Orion\RsiaPenerimaUndanganController::class)->only(['search'])
+    Orion::resource('penerima', \App\Http\Controllers\Orion\RsiaPenerimaUndanganController::class)
+        ->only(['search'])
         ->parameters(['penerima' => 'base64_no_surat']); // INFO : selesai
 
     Route::apiResource('penerima', \App\Http\Controllers\v2\RsiaPenerimaUndanganController::class)
@@ -15,13 +16,21 @@ Route::middleware(['user-aes', 'claim:role,pegawai'])->prefix('undangan')->group
 
     // ==================== KEHADIRAN RAPAT
     Route::apiResource('kehadiran', \App\Http\Controllers\v2\RsiaKehadiranRapatController::class)
-        ->only(['store', 'show'])
+        ->only(['store'])
         ->parameters(['kehadiran' => 'base64_no_surat']);
 });
 
 Route::middleware(['user-aes', 'claim:role,pegawai'])->group(function () {
     Orion::resource('undangan', \App\Http\Controllers\Orion\RsiaUndanganController::class)
-        ->only('search'); // INFO : selesai
+        ->only('search')
+        ->parameters(['undangan' => 'base64_no_surat']); // INFO : selesai
+
+    Route::apiResource('undangan', \App\Http\Controllers\v2\RsiaUndanganController::class)
+        ->only(['show'])
+        ->parameters(['undangan' => 'base64_no_surat']);
+
+    Route::get('undangan/{base64_no_surat}/notulen', [\App\Http\Controllers\v2\RsiaUndanganController::class, 'notulen'])
+        ->name('undangan.notulen');
 
     Route::resource('agenda', \App\Http\Controllers\v2\AgendaController::class)
         ->only(['index']);


### PR DESCRIPTION
**Deskripsi:**

Penambahan fitur untuk menampilkan penerima undangan beserta status kehadirannya secara default pada *endpoint* detail undangan.

- **Fitur Utama:**
  - Menampilkan daftar penerima undangan terkait pada respons *endpoint* detail undangan.
  - Menambahkan status kehadiran setiap penerima undangan melalui relasi kehadiran.
  - Data penerima undangan dan status kehadiran akan dimuat secara otomatis saat *endpoint* detail undangan diakses.

**Perubahan:**
- Modifikasi *endpoint* detail undangan untuk menyertakan informasi penerima dan kehadiran.
- Menambahkan logika relasi antara undangan, penerima, dan kehadiran dalam respons API.

**Reviewer:** @ferardian 

**Catatan Tambahan:**
- Pastikan untuk melakukan pengecekan terhadap data penerima dan kehadiran saat mengakses detail undangan.
- Dokumentasi API *perlu* diperbarui untuk mencerminkan perubahan pada respons.